### PR TITLE
Add support for AWS S3 storage for ephemeral storage platforms

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,6 +19,8 @@ whitenoise = "*"
 "psycopg2" = "*"
 easy-thumbnails = "*"
 python-dotenv = "*"
+django-storages = "*"
+"boto3" = "*"
 
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "373fbe640544ca753429ea7bfcf590b3504860d60d3c92b58e283c21449db167"
+            "sha256": "5c6e649c1ee522529906054b0c0ac0a0ccef79be069a3e8cab4ed3390ca2e729"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
@@ -9,9 +9,9 @@
             "os_name": "posix",
             "platform_machine": "x86_64",
             "platform_python_implementation": "CPython",
-            "platform_release": "4.4.0-101-generic",
+            "platform_release": "4.4.0-43-Microsoft",
             "platform_system": "Linux",
-            "platform_version": "#124-Ubuntu SMP Fri Nov 10 18:29:59 UTC 2017",
+            "platform_version": "#1-Microsoft Wed Dec 31 14:42:53 PST 2014",
             "python_full_version": "3.5.2",
             "python_version": "3.5",
             "sys_platform": "linux"
@@ -26,12 +26,26 @@
         ]
     },
     "default": {
+        "boto3": {
+            "hashes": [
+                "sha256:3cebf92fbc65d190f7d5618d3a46de341e5800ed24bc982dc8bb3ad2fa9478d0",
+                "sha256:5d7c47dbd14e6bbf1bee26da878091f31320bbb58aa72c5b08a8bf13c644d66e"
+            ],
+            "version": "==1.5.36"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:898f10e68a7a1c2be621caf046d29a8f782c0ea866d644d5be46472c00a3dee9",
+                "sha256:a80a23e080f4a93d11a1c067a69304dd407d18c358cba1e0df8c96f56c9e98b4"
+            ],
+            "version": "==1.8.50"
+        },
         "certifi": {
             "hashes": [
-                "sha256:244be0d93b71e93fc0a0a479862051414d0e00e16435707e5bf5000f92e04694",
-                "sha256:5ec74291ca1136b40f0379e1128ff80e866597e4e2c1e755739a913bbc3613c0"
+                "sha256:14131608ad2fd56836d33a71ee60fa1c82bc9d2c8d98b7bdbc631fe1b3cd1296",
+                "sha256:edbc3f203427eef571f79a7692bb160a2b0f7ccaa31953e99bd17e307cf63f7d"
             ],
-            "version": "==2017.11.5"
+            "version": "==2018.1.18"
         },
         "chardet": {
             "hashes": [
@@ -49,10 +63,10 @@
         },
         "decorator": {
             "hashes": [
-                "sha256:95a26b17806e284452bfd97fa20aa1e8cb4ee23542bda4dbac5e4562aa1642cd",
-                "sha256:7cb64d38cb8002971710c8899fbdfb859a23a364b7c99dab19d1f719c2ba16b5"
+                "sha256:94d1d8905f5010d74bbbd86c30471255661a14187c45f8d7f3e5aa8540fdb2e5",
+                "sha256:7d46dd9f3ea1cf5f06ee0e4e1277ae618cf48dfb10ada7c8427cd46c42702a0e"
             ],
-            "version": "==4.1.2"
+            "version": "==4.2.1"
         },
         "dj-database-url": {
             "hashes": [
@@ -63,10 +77,10 @@
         },
         "django": {
             "hashes": [
-                "sha256:af18618ce3291be5092893d8522fe3919661bf3a1fb60e3858ae74865a4f07c2",
-                "sha256:9614851d4a7ff8cbd32b73c6076441f377c45a5bbff7e771798fb02c43c31f47"
+                "sha256:7c8ff92285406fb349e765e9ade685eec7271d6f5c3f918e495a74768b765c99",
+                "sha256:dc3b61d054f1bced64628c62025d480f655303aea9f408e5996c339a543b45f0"
             ],
-            "version": "==2.0"
+            "version": "==2.0.2"
         },
         "django-filter": {
             "hashes": [
@@ -74,6 +88,13 @@
                 "sha256:ec0ef1ba23ef95b1620f5d481334413700fb33f45cd76d56a63f4b0b1d76976a"
             ],
             "version": "==1.1.0"
+        },
+        "django-storages": {
+            "hashes": [
+                "sha256:ab6be1538cf29511400bce83d0e5ca74d2e935cad82086063bcf5e7edacc1661",
+                "sha256:bc8e4c1f483608c5dd1212072fd41042f3ef2d2a2896ec4fb12dbc62c82996a0"
+            ],
+            "version": "==1.6.5"
         },
         "django-widget-tweaks": {
             "hashes": [
@@ -89,6 +110,14 @@
             ],
             "version": "==3.7.7"
         },
+        "docutils": {
+            "hashes": [
+                "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6",
+                "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
+                "sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274"
+            ],
+            "version": "==0.14"
+        },
         "easy-thumbnails": {
             "hashes": [
                 "sha256:e244d1f26027fc32c6ca60ffb0169a39099446f614b0433e907a2588ae7d9b95"
@@ -97,10 +126,10 @@
         },
         "faker": {
             "hashes": [
-                "sha256:2f6ccc9da046d4cd20401734cf6a1ac73a4e4d8256e7b283496ee6827ad2eb60",
-                "sha256:e928cf853ef69d7471421f2a3716a1239e43de0fa9855f4016ee0c9f1057328a"
+                "sha256:732ae449678a5c205ebc99e7e816f12eba6d6d1b02bd04d27ccf7edb2f4e6250",
+                "sha256:0857a92773c9cc6356c4c0c2aaa6f6ec83be94fc14fc0fd9e31904498d6fd388"
             ],
-            "version": "==0.8.8"
+            "version": "==0.8.11"
         },
         "gunicorn": {
             "hashes": [
@@ -122,6 +151,13 @@
                 "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"
             ],
             "version": "==0.2.0"
+        },
+        "jmespath": {
+            "hashes": [
+                "sha256:f11b4461f425740a1d908e9a3f7365c3d2e569f6ca68a2ff8bc5bcd9676edd63",
+                "sha256:6a81d4c9aa62caf061cb517b4d9ad1dd300374cd4706997aff9cd6aedd61fc64"
+            ],
+            "version": "==0.9.3"
         },
         "jsonschema": {
             "hashes": [
@@ -146,37 +182,31 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:910e7ae5eeee8d322775187692c5c66719cd58d230fbfd57245ea3cf75716910",
-                "sha256:f5c9ca457057cd5e12ddab36cded8b1f38bf1f45bf550d4ca2839b11ec57f597",
-                "sha256:d29e72413b66df23c75b9b469253c823698ea2e00f58e9e0df64b7a50696e8ac",
-                "sha256:539345898a4ae17421c159ae2a350901a5e6ce3da8f24168c6c67b3536e13de8",
-                "sha256:929928932f91082a168e36984179deddd58f8e98822ad2f33a2955d7c4eec596",
-                "sha256:62b09f3d1ea01d79c16a6642cb21599f53b9338c59971b2418a573155d2202ec",
-                "sha256:c4b1914d86c43399438518a2ac8bcba2fb64dd5a18efddded3783b9daae70933",
-                "sha256:6c6feb0647380db6e1d5d49ef9fb59c42240f25fb8df8b6e82ecb436c7e0621a",
-                "sha256:da2f47e46d7a93b73891d1981378717dc73c6ad5cc4fd23c934bfea7847fa958",
-                "sha256:4c767b6d9c9a071bb36ea34eb240ee5192fe0bc4c13be5e6c51e0350a30f7ac0",
-                "sha256:b2f98838f4bbc3bf23af7e97ffcad18a2dc6bbb0726796781e02b9347af6685f",
-                "sha256:11fcbed36c101a3b9c4636e791efccba82409ebbedaba938c97be8bdddd029cc",
-                "sha256:8969c8f987f8bcc3e30c014532cfc20e4a8f86a50c361596e086310853adacb7",
-                "sha256:2875e8055a1ea8d933b1c9d0f8714c0aa11c097bfadfcb8564c4d868fbf09a41",
-                "sha256:09b87d652c03508447d0f618e1d3ae57595acd3e0f0c11ac91bf68ed7bdb3a28",
-                "sha256:9cad35b911e150f00bb8080950c7e9f172714bbd0234f5ab74b4e3e2d9288b37",
-                "sha256:479863de17f66810db00bccf35289555365da45d3b053ccf539b95ab3b9c24f6",
-                "sha256:b162c6b044960b4ea0f42be049ce2af1d18c60f82748f0a27bd5ad182a731bf3",
-                "sha256:fa656dccfa9141774440575a6e7875d08b93f4a332eb5ae40877b26bed291c01",
-                "sha256:7dfa5b49fb2a080bd0d39bfbcff1177bacb14fcb28c857fd65fd0c18938935de",
-                "sha256:e8e0e75db757e41463888939d26c8058b4ecd25e563c597e9119f512dc0ee1da",
-                "sha256:c8dc6aa96882df6323bf9545934e37c6e05959bd789ae4b14d50509b093907aa",
-                "sha256:36ee86d5adbabc4fa2643a073f93d5504bdfed37a149a3a49f4dde259f35a750"
+                "sha256:e2335d56d2fd9fc4e3a3f2d3148aafec4962682375f429f05c45a64dacf19436",
+                "sha256:9b762e78739b6e021124adbea07611682db99cd3fca7f3c3a8b98b8f74ea5699",
+                "sha256:7d4c549e41507db4f04ec7cfab5597de8acf7871b16c9cf64cebcb9d39031ca6",
+                "sha256:b803306c4c201e7dcda0ce1b9a9c87f61a7c7ce43de2c60c8e56147b76849a1a",
+                "sha256:2da8dff91d489fea3e20155d41f4cd680de7d01d9a89fdd0ebb1bee6e72d3800",
+                "sha256:6b8c2daacbbffc83b4a2ba83a61aa3ce60c66340b07b962bd27b6c6bb175bee1",
+                "sha256:89b9419019c47ec87cf4cfca77d85da4611cc0be636ec87b5290346490b98450",
+                "sha256:49880b47d7272f902946dd995f346842c95fe275e2deb3082ef0495f0c718a69",
+                "sha256:3d7ddd5bdfb12ec9668edf1aa49a4a3eddb0db4661b57ea431477eb9a2468894",
+                "sha256:788e1757f8e409cd805a7cd82993cd9252fa19e334758a4c6eb5a8b334abb084",
+                "sha256:377def0873bbb1fbdedb14b3275b10a29b1b55619a3f7f775c4e7f9ce2461b9c",
+                "sha256:9501c9ccd081977ca5579a3ec4009d6baff6bacb04bf07214aade3324734195a",
+                "sha256:a1f5173df8190ef9c6235d260d70ca70c6fb029683ceb66e244c5cc6e335947a",
+                "sha256:12cf4b27039b88e407ad66894d99a957ef60fea0eeb442026af325add2ab264d",
+                "sha256:4e2fc841c8c642f7fd44591ef856ca409cedba6aea27928df34004c533839eee",
+                "sha256:e5ade7a69dccbd99c4fdbb95b6d091d941e62ffa588b0ed8fb0a2854118fef3f",
+                "sha256:6b1011ffc87d7e2b1b7bcc6dc21bdf177163658746ef778dcd21bf0516b9126c",
+                "sha256:a8bc80f69570e11967763636db9b24c1e3e3689881d10ae793cec74cf7a627b6",
+                "sha256:81b9d8f6450e752bd82e7d9618fa053df8db1725747880e76fb09710b57f78d0",
+                "sha256:e8522cad377cc2ef20fe13aae742cc265172910c98e8a0d6014b1a8d564019e2",
+                "sha256:a3d5dd437112292c707e54f47141be2f1100221242f07eda7bd8477f3ddc2252",
+                "sha256:c8000a6cbc5140629be8c038c9c9cdb3a1c85ff90bd4180ec99f0f0c73050b5e",
+                "sha256:fa0944650d5d3fb95869eaacd8eedbd2d83610c85e271bd9d3495ffa9bc4dc9c"
             ],
-            "version": "==1.13.3"
-        },
-        "olefile": {
-            "hashes": [
-                "sha256:61f2ca0cd0aa77279eb943c07f607438edf374096b66332fae1ee64a6f0f73ad"
-            ],
-            "version": "==0.44"
+            "version": "==1.14.1"
         },
         "pandas": {
             "hashes": [
@@ -209,97 +239,87 @@
         },
         "pillow": {
             "hashes": [
-                "sha256:cc6a5ed5b8f9d2f25e4e42d562e0ec4df3ce838f9e9b9d9d9b65fac6fe93a4cc",
-                "sha256:54898190b538a6c8fa4228e866ff2e7609da1ba9fd1d9cc5dc8ca591d37ce0a8",
-                "sha256:a336596b06e062b92eb8201a3b5dff07ae01c3a5d08ce5539d2da49b123f2be6",
-                "sha256:922aeb050bd52d8ce9531ab57fd2440bfe975900e8700fec385fb741c3c557c7",
-                "sha256:6d814aa655d94c63547fc3208cb6ab886ff1a64c543b31f52658663b1bb3f011",
-                "sha256:e66080685863444738f08e13081c287e340b6e4f8bd674a2e0da967776ac6f46",
-                "sha256:575a9b3468c82f38be0419cd39d35001ae95a0cc5226534e45430035fecef583",
-                "sha256:4fb8ab0f8895fb946454ef6ffe806f49ee387095f2d6112ae24670e5fb8fbcd9",
-                "sha256:1d742642d01914b7e0cf6fd597a51f57d21fd68f794cf84803e03e72db78a261",
-                "sha256:59cef683d79b85d55a950c1e61dc7b6be0c45a5074692746354cd9a8ace1cd17",
-                "sha256:822e4fc261d12fa44d88dadee0e93d59663db94d962d4ffffbf09b1fe5e5be51",
-                "sha256:a6f43511c79bed431ec2b56e55150b5222c732cd9e5f80e77a44e068e94c71fc",
-                "sha256:2046a2001e2c413998951cc28aa0dbfd4cff846a12e24c2145d42630d5104094",
-                "sha256:39c7c9dcf64430091e30ef14d4191b4cae9b7b5ff29762357730aac4866fb189",
-                "sha256:f2d71951f473744ac617b645b62d0c4df5372ef4618c425646bfe5e2e8878e61",
-                "sha256:9adcfa2477b7e279ebeee75b49f535518201bbd7d26ca2ef1cf6751cb6e658e8",
-                "sha256:0e3b56364a2c772c961a8faad8a835d3f24d8848310de035c9e07cc006035cbc",
-                "sha256:92087cb92a968421f42235f7d8153f4766b6ba213a6efb36b8060f3c9d294569",
-                "sha256:53eaec751151b5713a15b1cd62b06d0fc16d72f56623c15448728c554c30770b",
-                "sha256:e595312f67962d6b4fde3b7dffaaaca4becefa522d677676bb57b0ec5f8f921a",
-                "sha256:dc32362d0cadf18c3aef7040455760106cafe7dd3c211dc27c507e746376bb56",
-                "sha256:759e5e3e99c4ac87b99e9288a75236c63173d1bb24c8d3f9d9d2c8332fceeb0a",
-                "sha256:b13106cb83a3b7d1a02fafb94bfafbc980465ba948b76ea1996245959c6783d2",
-                "sha256:9184b9788a9cf677e53626a4dc141136a22d349a5480479b98defd3cfb5015a4",
-                "sha256:be803fae6af36639524a0f6861a8cface67bbec66c3416c3eaf592f1d45b8b20",
-                "sha256:effa82e72f5064439a3d2c7ff615b999eb1c4d65bb1f1e6ee6e2ddb345b3e81e",
-                "sha256:9dc002a914cefa710dcb9fb204d34f6cd822662047a6038178f5fc9bfa7be961",
-                "sha256:7b3cf7a80608ed661b77793f64e1f2bd1e77136ad0b750aa2c81fac9c7e2c785",
-                "sha256:a9bad3405a642649e68568fe9832e8f6ae585354ab0b4ae250816ead11a553a2",
-                "sha256:4d3dbd93b131013a71b2e98530dd4945a03c7994d42381e44a921dd8bec300bc",
-                "sha256:9a1514bee2e32e0d4c0f55ba7a20f4387f883e37c7d2db64ca50449ffebe86cc",
-                "sha256:a9721fe1f6fdfe0c108ea81b1a05dc216f1ec5bb65ef1de1d85fd00494d019e0",
-                "sha256:e75d745306ec8aac0e6903358fdfc7fb6854febe551ed753ee7a1cad058b61bb",
-                "sha256:ccc9c1f5ba413fc5ee09bc78de7dd2ad8e189edb48f3bc38acedd04a7f43a0c1",
-                "sha256:150e24462fd106074a9a63417a55fbb0c633716cef9511f1bd7a773972de14f4",
-                "sha256:250d8470661fd657c2583672ab5139f40e7f2ef28ecdc90f87563af0b27f6fba",
-                "sha256:a97c715d44efd5b4aa8d739b8fad88b93ed79f1b33fc2822d5802043f3b1b527",
-                "sha256:dbefe5aa0882f00f12eceb3fb7df57105cd87fae767ca025db4685b7577c2390",
-                "sha256:62a7bbf0a1120ff07a99ddedd383779a8d80bd9d363f3964b2b43a26cef6ea50",
-                "sha256:42b4a67949085ddd4559c3c716a00a275fb45cb2c3a3aeec95c4b94419b7c243",
-                "sha256:0ac037e6c1746d63a1ea354f0d5974d8f3f984fc0333be373ad193711a89b1e9",
-                "sha256:8989cbf10ea07fc9982ec86116f6234bb3e44da481874ac94650d6176f60106f",
-                "sha256:77834551d3e928f3da922ce9dfb5c8db46758ea2f2922d4c5835a5b67a222aff",
-                "sha256:c00301e807084706bd46a1c56694ee235debe68eaf482c0186edfe07b93a9f6a",
-                "sha256:0163bd681d3488e2e9c26f4fbbfefcfb7f32259c431bfd2c3bc25574708a8b8c",
-                "sha256:223b06c337d8d60fb65af3b540ab1fa4644931d61d1fddf6e32f7a0e496685f2",
-                "sha256:1ab641cb7daf88e88ede8d3b89b7bd68a7099d8671160492d5e6845e24426080"
+                "sha256:718ec7a122b28d64afc5fbc3a9b99bb0545ef511373cac06fe7624520e82cb20",
+                "sha256:801cca8923508311bf5d6d0f7da5362552e8208ebd8ec0d7b9f2cd2ff5705734",
+                "sha256:43334f9581cd067945b8898cef9eb5714ee4883f8de0304c011f1dbdb1d4e2aa",
+                "sha256:153ec6f18f7b61641e0e6e502acfaf4a06c9aba2ea11c0b4b3578ea9f13a4a4a",
+                "sha256:25193f934d37d836a6b1f4c062ce574a96cbca7c6d9dc8ddfbbac7f9c54deaa4",
+                "sha256:b85f703c2ffe539313e39ce0676bed0f355cec45a16e58c9ab7417445843047c",
+                "sha256:8580fc58074a16b749905b26cf8363f7b628dd167ba0130f5382cdc91c86b509",
+                "sha256:2fcde9954c8882d1c7f93bb828caa34a4c5e3ee69dbc7895dc8652ad972b455a",
+                "sha256:1a5b93084e01328a1cb1ecdad99d11d75e881e89a95f88d85b523646553b36c2",
+                "sha256:b2240f298482f823576f397bb9f32ea913ad9456c526e141bc6f0a022b37a3e8",
+                "sha256:b1d33c63a55d0d85df0ad02b2c16158fb4d8153afa7b908f1a67330fac694cd6",
+                "sha256:6977cf073d83358b34f93abf5c1f1193b88675fe0e4441e0e28318bc3dcba7a0",
+                "sha256:1912b7230459fd53682dae32b83cbd8e5d642ba36d4be18566f00a9c063aa13d",
+                "sha256:4bd4a71501b6d51db4abc07e1f43f5a6fed0a1a9583cca0b401d6af50284b0db",
+                "sha256:0013f590a8f260df60bcfd65db19d18efc04e7f046c3c82a40e2e2b3292a937c",
+                "sha256:a224651a81e45ef4f1d0164e256c5f6b4abb49f2ae8f22ba2f3a9d0ff338e608",
+                "sha256:c793dfaa130847ccff958492b76ae8b9304e60b8a79a92962cb19e368276a22b",
+                "sha256:0b899ee80920bb533f26581af9b4660bc12aff4562555afe74e429101ebf3c94",
+                "sha256:9525cd680a6f9e80c6c0af03cf973e6505c59f60b4745f682cd1a449e54b31bb",
+                "sha256:35f7d998b8e82fb3fb51ff88b30485eb81cd7dd56ec7e1a8deba23eb88532d44",
+                "sha256:5b0d657460d9f3615876fec6306e97ca15a471f6169b622d76a47e270998acf1",
+                "sha256:ddd16ab250b4fc97db1c47407e78c25216a75c29d29d10ad37e51b7a2ec7b2c3",
+                "sha256:b9f63451084a718eccdeb1e382768c94647915653af4d6019f64560d9e98642b",
+                "sha256:a370d1c570f1d72e877099651e752332444b1c5009381f043c9da5fd47f3ebae",
+                "sha256:dc4b018d5c9b636f7546583c5591b9ea00c328c3e5871992ef5b95bac353f097",
+                "sha256:e126ff4fed71e78333840c07279e1617f63cfca76d63ad5b27d65a7277206a3d",
+                "sha256:fcf64c91fd44485100a2965d23bb0e227d093e91f7e776c5ca3b32574766eb56",
+                "sha256:2c042352b430d678db50c78c5214e19638eff8b688941271da2de21fd298dfe5",
+                "sha256:17fe25efc785194d48c38fad85dce470013ba19d2fb66639e149f14bccf1327f",
+                "sha256:2e818dbe445e86fc6c266973fe540c35125c42eb2cf13a6095e9adaa89c0deb5",
+                "sha256:135e9aa65150c53f7db85bf2bebb8a0e1a48ea850e80cf66e16dd04fa09d309c",
+                "sha256:7dfbefdb3fb911ca9faed307bf309861e9995e36cca6b761c7ba6d9b77a9744a",
+                "sha256:12f29d6c23424f704c66b5b68c02fe0b571504459605cfe36ab8158359b0e1bb",
+                "sha256:f8d49be8c282df8d2e1ab6ab53ab8abd859b1fa6fed384457ee85c9eff64ef97",
+                "sha256:82b172e3264e62372c01b5b009b5b1a02fbb9276cbe5cc57ab00a6d6e5ed9a18",
+                "sha256:57aa6198ba8acba1313c3b743e267d821a60cac77e6026caf0b55ca58d3d23be",
+                "sha256:d60c1625b108432ace8b1fa1a584017e5efa73f107d0f493c7f39c79bebf1d41",
+                "sha256:82d1ff571489765df2816785d532e243bde213752156c227fca595723ec5ff42",
+                "sha256:37cc0339abfa9e295c75d9a7f227d35cb44716feb95057f9449c4a9e9a17daf7",
+                "sha256:931030d1d6282b7900e6b0a7ff9ecdb503b5e1e6781800dab2b71a9f39405bff",
+                "sha256:5cd36804f9f06a914a883fe682df5711d16d7b4f44d43189c5f013e7cd91e149"
             ],
-            "version": "==4.3.0"
+            "version": "==5.0.0"
         },
         "plotly": {
             "hashes": [
-                "sha256:dadd2263f1c0449b248fd3742a077d9594935921a9597529be76d6a841237ab0"
+                "sha256:f588991dce15437debd825eca935c8cfbabf438cdc0dcd2ce7a88f429d982f69"
             ],
-            "version": "==2.2.3"
+            "version": "==2.4.1"
         },
         "psycopg2": {
             "hashes": [
-                "sha256:594aa9a095de16614f703d759e10c018bdffeafce2921b8e80a0e8a0ebbc12e5",
-                "sha256:1cf5d84290c771eeecb734abe2c6c3120e9837eb12f99474141a862b9061ac51",
-                "sha256:0344b181e1aea37a58c218ccb0f0f771295de9aa25a625ed076e6996c6530f9e",
-                "sha256:25250867a4cd1510fb755ef9cb38da3065def999d8e92c44e49a39b9b76bc893",
-                "sha256:317612d5d0ca4a9f7e42afb2add69b10be360784d21ce4ecfbca19f1f5eadf43",
-                "sha256:9d6266348b15b4a48623bf4d3e50445d8e581da413644f365805b321703d0fac",
-                "sha256:ddca39cc55877653b5fcf59976d073e3d58c7c406ef54ae8e61ddf8782867182",
-                "sha256:988d2ec7560d42ef0ac34b3b97aad14c4f068792f00e1524fa1d3749fe4e4b64",
-                "sha256:7a9c6c62e6e05df5406e9b5235c31c376a22620ef26715a663cee57083b3c2ea",
-                "sha256:7a75565181e75ba0b9fb174b58172bf6ea9b4331631cfe7bafff03f3641f5d73",
-                "sha256:94e4128ba1ea56f02522fffac65520091a9de3f5c00da31539e085e13db4771b",
-                "sha256:92179bd68c2efe72924a99b6745a9172471931fc296f9bfdf9645b75eebd6344",
-                "sha256:b9358e203168fef7bfe9f430afaed3a2a624717a1d19c7afa7dfcbd76e3cd95c",
-                "sha256:009e0bc09a57dbef4b601cb8b46a2abad51f5274c8be4bba276ff2884cd4cc53",
-                "sha256:d3ac07240e2304181ffdb13c099840b5eb555efc7be9344503c0c03aa681de79",
-                "sha256:40fa5630cd7d237cd93c4d4b64b9e5ed9273d1cfce55241c7f9066f5db70629d",
-                "sha256:6c2f1a76a9ebd9ecf7825b9e20860139ca502c2bf1beabf6accf6c9e66a7e0c3",
-                "sha256:37f54452c7787dbdc0a634ca9773362b91709917f0b365ed14b831f03cbd34ba",
-                "sha256:8f5942a4daf1ffac42109dc4a72f786af4baa4fa702ede1d7c57b4b696c2e7d6",
-                "sha256:bf708455cd1e9fa96c05126e89a0c59b200d086c7df7bbafc7d9be769e4149a3",
-                "sha256:82c40ea3ac1555e0462803380609fbe8b26f52620f3d4f8eb480cfd8ceed8a14",
-                "sha256:207ba4f9125a0a4200691e82d5eee7ea1485708eabe99a07fc7f08696fae62f4",
-                "sha256:0cd4c848f0e9d805d531e44973c8f48962e20eb7fc0edac3db4f9dbf9ed5ab82",
-                "sha256:57baf63aeb2965ca4b52613ce78e968b6d2bde700c97f6a7e8c6c236b51ab83e",
-                "sha256:2954557393cfc9a5c11a5199c7a78cd9c0c793a047552d27b1636da50d013916",
-                "sha256:7c31dade89634807196a6b20ced831fbd5bec8a21c4e458ea950c9102c3aa96f",
-                "sha256:1286dd16d0e46d59fa54582725986704a7a3f3d9aca6c5902a7eceb10c60cb7e",
-                "sha256:697ff63bc5451e0b0db48ad205151123d25683b3754198be7ab5fcb44334e519",
-                "sha256:fc993c9331d91766d54757bbc70231e29d5ceb2d1ac08b1570feaa0c38ab9582",
-                "sha256:9d64fed2681552ed642e9c0cc831a9e95ab91de72b47d0cb68b5bf506ba88647",
-                "sha256:5c3213be557d0468f9df8fe2487eaf2990d9799202c5ff5cb8d394d09fad9b2a"
+                "sha256:aeaba399254ca79c299d9fe6aa811d3c3eac61458dee10270de7f4e71c624998",
+                "sha256:1d90379d01d0dc50ae9b40c863933d87ff82d51dd7d52cea5d1cb7019afd72cd",
+                "sha256:36030ca7f4b4519ee4f52a74edc4ec73c75abfb6ea1d80ac7480953d1c0aa3c3",
+                "sha256:7cbc3b21ce2f681ca9ad2d8c0901090b23a30c955e980ebf1006d41f37068a95",
+                "sha256:b178e0923c93393e16646155794521e063ec17b7cc9f943f15b7d4b39776ea2c",
+                "sha256:fe6a7f87356116f5ea840c65b032af17deef0e1a5c34013a2962dd6f99b860dd",
+                "sha256:6f302c486132f8dd11f143e919e236ea4467d53bf18c451cac577e6988ecbd05",
+                "sha256:888bba7841116e529f407f15c6d28fe3ef0760df8c45257442ec2f14f161c871",
+                "sha256:932a4c101af007cb3132b1f8a9ffef23386acc53dad46536dc5ba43a3235ae02",
+                "sha256:179c52eb870110a8c1b460c86d4f696d58510ea025602cd3f81453746fccb94f",
+                "sha256:33f9e1032095e1436fa9ec424abcbd4c170da934fb70e391c5d78275d0307c75",
+                "sha256:092a80da1b052a181b6e6c765849c9b32d46c5dac3b81bf8c9b83e697f3cdbe8",
+                "sha256:f3d3a88128f0c219bdc5b2d9ccd496517199660cea021c560a3252116df91cbd",
+                "sha256:19983b77ec1fc2a210092aa0333ee48811fd9fb5f194c6cd5b927ed409aea5f8",
+                "sha256:027ae518d0e3b8fff41990e598bc7774c3d08a3a20e9ecc0b59fb2aaaf152f7f",
+                "sha256:363fbbf4189722fc46779be1fad2597e2c40b3f577dc618f353a46391cf5d235",
+                "sha256:d74cf9234ba76426add5e123449be08993a9b13ff434c6efa3a07caa305a619f",
+                "sha256:32702e3bd8bfe12b36226ba9846ed9e22336fc4bd710039d594b36bd432ae255",
+                "sha256:8eb94c0625c529215b53c08fb4e461546e2f3fc96a49c13d5474b5ad7aeab6cf",
+                "sha256:8ebba5314c609a05c6955e5773c7e0e57b8dd817e4f751f30de729be58fa5e78",
+                "sha256:27467fd5af1dcc0a82d72927113b8f92da8f44b2efbdb8906bd76face95b596d",
+                "sha256:b68e89bb086a9476fa85298caab43f92d0a6af135a5f433d1f6b6d82cafa7b55",
+                "sha256:0b9851e798bae024ed1a2a6377a8dab4b8a128a56ed406f572f9f06194e4b275",
+                "sha256:733166464598c239323142c071fa4c9b91c14359176e5ae7e202db6bcc1d2eb5",
+                "sha256:ad75fe10bea19ad2188c5cb5fc4cdf53ee808d9b44578c94a3cd1e9fc2beb656",
+                "sha256:8966829cb0d21a08a3c5ac971a2eb67c3927ae27c247300a8476554cc0ce2ae8",
+                "sha256:8bf51191d60f6987482ef0cfe8511bbf4877a5aa7f313d7b488b53189cf26209"
             ],
-            "version": "==2.7.3.2"
+            "version": "==2.7.4"
         },
         "python-dateutil": {
             "hashes": [
@@ -317,17 +337,17 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:80af0f3008046b9975242012a985f04c5df1f01eed4ec1633d56cc47a75a6a48",
-                "sha256:feb2365914948b8620347784b6b6da356f31c9d03560259070b2f30cff3d469d",
-                "sha256:59707844a9825589878236ff2f4e0dc9958511b7ffaae94dc615da07d4a68d33",
-                "sha256:d0ef5ef55ed3d37854320d4926b04a4cb42a2e88f71da9ddfdacfde8e364f027",
-                "sha256:c41c62827ce9cafacd6f2f7018e4f83a6f1986e87bfd000b8cfbd4ab5da95f1a",
-                "sha256:8cc90340159b5d7ced6f2ba77694d946fc975b09f1a51d93f3ce3bb399396f94",
-                "sha256:dd2e4ca6ce3785c8dd342d1853dd9052b19290d5bf66060846e5dc6b8d6667f7",
-                "sha256:699d18a2a56f19ee5698ab1123bbcc1d269d061996aeb1eda6d89248d3542b82",
-                "sha256:fae4cffc040921b8a2d60c6cf0b5d662c1190fe54d718271db4eb17d44a185b7"
+                "sha256:ed6509d9af298b7995d69a440e2822288f2eca1681b8cce37673dbb10091e5fe",
+                "sha256:f93ddcdd6342f94cea379c73cddb5724e0d6d0a1c91c9bdef364dc0368ba4fda",
+                "sha256:61242a9abc626379574a166dc0e96a66cd7c3b27fc10868003fa210be4bff1c9",
+                "sha256:ba18e6a243b3625513d85239b3e49055a2f0318466e0b8a92b8fb8ca7ccdf55f",
+                "sha256:07edfc3d4d2705a20a6e99d97f0c4b61c800b8232dc1c04d87e8554f130148dd",
+                "sha256:3a47ff71597f821cd84a162e71593004286e5be07a340fd462f0d33a760782b5",
+                "sha256:5bd55c744e6feaa4d599a6cbd8228b4f8f9ba96de2c38d56f08e534b3c9edf0d",
+                "sha256:887ab5e5b32e4d0c86efddd3d055c1f363cbaa583beb8da5e22d2fa2f64d51ef",
+                "sha256:410bcd1d6409026fbaa65d9ed33bf6dd8b1e94a499e32168acfc7b332e4095c0"
             ],
-            "version": "==2017.3"
+            "version": "==2018.3"
         },
         "requests": {
             "hashes": [
@@ -335,6 +355,13 @@
                 "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
             ],
             "version": "==2.18.4"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:c7a9ec356982d5e9ab2d4b46391a7d6a950e2b04c472419f5fdec70cc0ada72f",
+                "sha256:90dc18e028989c609146e241ea153250be451e05ecc0c2832565231dacdf59c1"
+            ],
+            "version": "==0.1.13"
         },
         "six": {
             "hashes": [
@@ -345,10 +372,10 @@
         },
         "text-unidecode": {
             "hashes": [
-                "sha256:02efd86b9c0f489f858d8cead62e94d3760dab444054b258734716f7602330a3",
-                "sha256:d0afd5e8a7ac69bfb1372e1bbfa3c63c22e3db8ae1284690e96b45c4430d08d0"
+                "sha256:801e38bd550b943563660a91de8d4b6fa5df60a542be9093f7abf819f86050cc",
+                "sha256:5a1375bb2ba7968740508ae38d92e1f889a0832913cb1c447d5e2046061a396d"
             ],
-            "version": "==1.1"
+            "version": "==1.2"
         },
         "traitlets": {
             "hashes": [
@@ -375,10 +402,10 @@
     "develop": {
         "certifi": {
             "hashes": [
-                "sha256:244be0d93b71e93fc0a0a479862051414d0e00e16435707e5bf5000f92e04694",
-                "sha256:5ec74291ca1136b40f0379e1128ff80e866597e4e2c1e755739a913bbc3613c0"
+                "sha256:14131608ad2fd56836d33a71ee60fa1c82bc9d2c8d98b7bdbc631fe1b3cd1296",
+                "sha256:edbc3f203427eef571f79a7692bb160a2b0f7ccaa31953e99bd17e307cf63f7d"
             ],
-            "version": "==2017.11.5"
+            "version": "==2018.1.18"
         },
         "chardet": {
             "hashes": [
@@ -389,48 +416,44 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:d1ee76f560c3c3e8faada866a07a32485445e16ed2206ac8378bd90dadffb9f0",
-                "sha256:007eeef7e23f9473622f7d94a3e029a45d55a92a1f083f0f3512f5ab9a669b05",
-                "sha256:17307429935f96c986a1b1674f78079528833410750321d22b5fb35d1883828e",
-                "sha256:845fddf89dca1e94abe168760a38271abfc2e31863fbb4ada7f9a99337d7c3dc",
-                "sha256:3f4d0b3403d3e110d2588c275540649b1841725f5a11a7162620224155d00ba2",
-                "sha256:4c4f368ffe1c2e7602359c2c50233269f3abe1c48ca6b288dcd0fb1d1c679733",
-                "sha256:f8c55dd0f56d3d618dfacf129e010cbe5d5f94b6951c1b2f13ab1a2f79c284da",
-                "sha256:cdd92dd9471e624cd1d8c1a2703d25f114b59b736b0f1f659a98414e535ffb3d",
-                "sha256:2ad357d12971e77360034c1596011a03f50c0f9e1ecd12e081342b8d1aee2236",
-                "sha256:e9a0e1caed2a52f15c96507ab78a48f346c05681a49c5b003172f8073da6aa6b",
-                "sha256:eea9135432428d3ca7ee9be86af27cb8e56243f73764a9b6c3e0bda1394916be",
-                "sha256:700d7579995044dc724847560b78ac786f0ca292867447afda7727a6fbaa082e",
-                "sha256:66f393e10dd866be267deb3feca39babba08ae13763e0fc7a1063cbe1f8e49f6",
-                "sha256:5ff16548492e8a12e65ff3d55857ccd818584ed587a6c2898a9ebbe09a880674",
-                "sha256:d00e29b78ff610d300b2c37049a41234d48ea4f2d2581759ebcf67caaf731c31",
-                "sha256:87d942863fe74b1c3be83a045996addf1639218c2cb89c5da18c06c0fe3917ea",
-                "sha256:358d635b1fc22a425444d52f26287ae5aea9e96e254ff3c59c407426f44574f4",
-                "sha256:81912cfe276e0069dca99e1e4e6be7b06b5fc8342641c6b472cb2fed7de7ae18",
-                "sha256:079248312838c4c8f3494934ab7382a42d42d5f365f0cf7516f938dbb3f53f3f",
-                "sha256:b0059630ca5c6b297690a6bf57bf2fdac1395c24b7935fd73ee64190276b743b",
-                "sha256:493082f104b5ca920e97a485913de254cbe351900deed72d4264571c73464cd0",
-                "sha256:e3ba9b14607c23623cf38f90b23f5bed4a3be87cbfa96e2e9f4eabb975d1e98b",
-                "sha256:82cbd3317320aa63c65555aa4894bf33a13fb3a77f079059eb5935eea415938d",
-                "sha256:9721f1b7275d3112dc7ccf63f0553c769f09b5c25a26ee45872c7f5c09edf6c1",
-                "sha256:bd4800e32b4c8d99c3a2c943f1ac430cbf80658d884123d19639bcde90dad44a",
-                "sha256:f29841e865590af72c4b90d7b5b8e93fd560f5dea436c1d5ee8053788f9285de",
-                "sha256:f3a5c6d054c531536a83521c00e5d4004f1e126e2e2556ce399bef4180fbe540",
-                "sha256:dd707a21332615108b736ef0b8513d3edaf12d2a7d5fc26cd04a169a8ae9b526",
-                "sha256:2e1a5c6adebb93c3b175103c2f855eda957283c10cf937d791d81bef8872d6ca",
-                "sha256:f87f522bde5540d8a4b11df80058281ac38c44b13ce29ced1e294963dd51a8f8",
-                "sha256:a7cfaebd8f24c2b537fa6a271229b051cdac9c1734bb6f939ccfc7c055689baa",
-                "sha256:309d91bd7a35063ec7a0e4d75645488bfab3f0b66373e7722f23da7f5b0f34cc",
-                "sha256:0388c12539372bb92d6dde68b4627f0300d948965bbb7fc104924d715fdc0965",
-                "sha256:ab3508df9a92c1d3362343d235420d08e2662969b83134f8a97dc1451cbe5e84",
-                "sha256:43a155eb76025c61fc20c3d03b89ca28efa6f5be572ab6110b2fb68eda96bfea",
-                "sha256:f98b461cb59f117887aa634a66022c0bd394278245ed51189f63a036516e32de",
-                "sha256:b6cebae1502ce5b87d7c6f532fa90ab345cfbda62b95aeea4e431e164d498a3d",
-                "sha256:a4497faa4f1c0fc365ba05eaecfb6b5d24e3c8c72e95938f9524e29dadb15e76",
-                "sha256:2b4d7f03a8a6632598cbc5df15bbca9f778c43db7cf1a838f4fa2c8599a8691a",
-                "sha256:1afccd7e27cac1b9617be8c769f6d8a6d363699c9b86820f40c74cfb3328921c"
+                "sha256:7608a3dd5d73cb06c531b8925e0ef8d3de31fed2544a7de6c63960a1e73ea4bc",
+                "sha256:3a2184c6d797a125dca8367878d3b9a178b6fdd05fdc2d35d758c3006a1cd694",
+                "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80",
+                "sha256:0b136648de27201056c1869a6c0d4e23f464750fd9a9ba9750b8336a244429ed",
+                "sha256:337ded681dd2ef9ca04ef5d93cfc87e52e09db2594c296b4a0a3662cb1b41249",
+                "sha256:3eb42bf89a6be7deb64116dd1cc4b08171734d721e7a7e57ad64cc4ef29ed2f1",
+                "sha256:be6cfcd8053d13f5f5eeb284aa8a814220c3da1b0078fa859011c7fffd86dab9",
+                "sha256:69bf008a06b76619d3c3f3b1983f5145c75a305a0fea513aca094cae5c40a8f5",
+                "sha256:2eb564bbf7816a9d68dd3369a510be3327f1c618d2357fa6b1216994c2e3d508",
+                "sha256:9d6dd10d49e01571bf6e147d3b505141ffc093a06756c60b053a859cb2128b1f",
+                "sha256:701cd6093d63e6b8ad7009d8a92425428bc4d6e7ab8d75efbb665c806c1d79ba",
+                "sha256:5a13ea7911ff5e1796b6d5e4fbbf6952381a611209b736d48e675c2756f3f74e",
+                "sha256:c1bb572fab8208c400adaf06a8133ac0712179a334c09224fb11393e920abcdd",
+                "sha256:03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba",
+                "sha256:28b2191e7283f4f3568962e373b47ef7f0392993bb6660d079c62bd50fe9d162",
+                "sha256:de4418dadaa1c01d497e539210cb6baa015965526ff5afc078c57ca69160108d",
+                "sha256:8c3cb8c35ec4d9506979b4cf90ee9918bc2e49f84189d9bf5c36c0c1119c6558",
+                "sha256:7e1fe19bd6dce69d9fd159d8e4a80a8f52101380d5d3a4d374b6d3eae0e5de9c",
+                "sha256:6bc583dc18d5979dc0f6cec26a8603129de0304d5ae1f17e57a12834e7235062",
+                "sha256:198626739a79b09fa0a2f06e083ffd12eb55449b5f8bfdbeed1df4910b2ca640",
+                "sha256:7aa36d2b844a3e4a4b356708d79fd2c260281a7390d678a10b91ca595ddc9e99",
+                "sha256:3d72c20bd105022d29b14a7d628462ebdc61de2f303322c0212a054352f3b287",
+                "sha256:4635a184d0bbe537aa185a34193898eee409332a8ccb27eea36f262566585000",
+                "sha256:e05cb4d9aad6233d67e0541caa7e511fa4047ed7750ec2510d466e806e0255d6",
+                "sha256:76ecd006d1d8f739430ec50cc872889af1f9c1b6b8f48e29941814b09b0fd3cc",
+                "sha256:7d3f553904b0c5c016d1dad058a7554c7ac4c91a789fca496e7d8347ad040653",
+                "sha256:3c79a6f7b95751cdebcd9037e4d06f8d5a9b60e4ed0cd231342aa8ad7124882a",
+                "sha256:56e448f051a201c5ebbaa86a5efd0ca90d327204d8b059ab25ad0f35fbfd79f1",
+                "sha256:ac4fef68da01116a5c117eba4dd46f2e06847a497de5ed1d64bb99a5fda1ef91",
+                "sha256:1c383d2ef13ade2acc636556fd544dba6e14fa30755f26812f54300e401f98f2",
+                "sha256:b8815995e050764c8610dbc82641807d196927c3dbed207f0a079833ffcf588d",
+                "sha256:104ab3934abaf5be871a583541e8829d6c19ce7bde2923b2751e0d3ca44db60a",
+                "sha256:9e112fcbe0148a6fa4f0a02e8d58e94470fc6cb82a5481618fea901699bf34c4",
+                "sha256:15b111b6a0f46ee1a485414a52a7ad1d703bdf984e9ed3c288a4414d3871dcbd",
+                "sha256:e4d96c07229f58cb686120f168276e434660e4358cc9cf3b0464210b04913e77",
+                "sha256:f8a923a85cb099422ad5a2e345fe877bbc89a8a8b23235824a93488150e45f6e"
             ],
-            "version": "==4.4.2"
+            "version": "==4.5.1"
         },
         "coveralls": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/babybuddy/Lobby)
 
 A buddy for babies! Helps caregivers track sleep, feedings, diaper changes, and
-tummy time to learn about and predict baby's needs without (*as much*) guess 
+tummy time to learn about and predict baby's needs without (*as much*) guess
 work.
 
 ![Baby Buddy desktop view](screenshot.png)
@@ -42,7 +42,7 @@ The demo instance resets every hour. Login credentials are:
 
 ## Deployment
 
-The default user name and password for Baby Buddy is `admin`/`admin`. For any 
+The default user name and password for Baby Buddy is `admin`/`admin`. For any
 deployment, **log in and change the default admin password immediately**.
 
 Many of Baby Buddy's configuration settings can be controlled using environment
@@ -51,7 +51,7 @@ variables - see [Configuration](#configuration) for detailed information.
 ### AWS Elastic Beanstalk
 
 A basic [Elastic Beanstalk](https://aws.amazon.com/elasticbeanstalk/)
-configuration is provided in `.ebextensions/babybuddy.config`.   The steps 
+configuration is provided in `.ebextensions/babybuddy.config`.   The steps
 below are a rough guide to deployment. See [Working with Python](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/create-deploy-python-apps.html)
 for detailed information.
 
@@ -62,7 +62,7 @@ for detailed information.
 1. Enter the cloned/downloaded directory
 
         cd babybuddy
-        
+
 1. Change the `SECRET_KEY` value to something random in `.ebextensions/babybuddy.config`
 
 1. [Create an IAM user](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html) in AWS with EB, EC2, RDS and S3 privileges.
@@ -70,17 +70,17 @@ for detailed information.
 1. Initialize the Elastic Bean application (using the IAM user from the previous step)
 
         eb init -p python-3.6
-        
+
 1. Create/deploy the environment! :rocket:
 
         eb create -db -db.engine postgres
 
-The create command will also do an initial deployment. Run `eb deploy` to 
+The create command will also do an initial deployment. Run `eb deploy` to
 redeploy the app (e.g. if there are errors or settings are changed).
 
 ### Docker
 
-A Docker deploy requires [Docker](http://docker.com/) and 
+A Docker deploy requires [Docker](http://docker.com/) and
 [Docker Compose](https://docs.docker.com/compose/overview/) to create two
 containers - one for the database and one for the application. Baby Buddy uses a
 [multi-stage build](https://docs.docker.com/engine/userguide/eng-image/multistage-build/),
@@ -91,14 +91,14 @@ which requires Docker version 17.05 or newer.
 
         cp docker.env.example docker.env
         editor docker.env
-        
-    *See [Configuration](#configuration) for other settings that can be 
+
+    *See [Configuration](#configuration) for other settings that can be
     controlled by environment variables added to the `docker.env` file.*
-        
+
 1. Build/run the application
 
         docker-compose up -d
-            
+
 1. Initialize the database *(first run/after updates)*
 
         docker-compose exec app python manage.py migrate
@@ -106,16 +106,16 @@ which requires Docker version 17.05 or newer.
 1. Initialize static assets *(first run/after updates)*
 
         docker-compose exec app python manage.py collectstatic
-        
-The app should now be locally available at 
-[http://127.0.0.1:8000](http://127.0.0.1:8000). See 
+
+The app should now be locally available at
+[http://127.0.0.1:8000](http://127.0.0.1:8000). See
 [Get Started, Part 6: Deploy your app](https://docs.docker.com/get-started/part6/)
 for detailed information about how to deployment methods with Docker.
 
 ### Nanobox
 
-An example [Nanobox](https://nanobox.io/) configuration, `boxfile.yml`, is 
-provided with Baby Buddy. The steps below are a rough guide to deployment. See 
+An example [Nanobox](https://nanobox.io/) configuration, `boxfile.yml`, is
+provided with Baby Buddy. The steps below are a rough guide to deployment. See
 [Create and Deploy a Custom Django App](https://guides.nanobox.io/python/django/)
 for detailed information about Nanobox's deployment and configuration process.
 
@@ -126,13 +126,13 @@ for detailed information about Nanobox's deployment and configuration process.
 1. Enter the cloned/downloaded directory
 
         cd babybuddy
-    
+
 1. Add the `SECRET_KEY` and `DJANGO_SETTINGS_MODULE` environment variables
 
         nanobox evar add DJANGO_SETTINGS_MODULE=babybuddy.settings.nanobox
         nanobox evar add SECRET_KEY=<CHANGE TO SOMETHING RANDOM>
-        
-    *See [Configuration](#configuration) for other settings that can be 
+
+    *See [Configuration](#configuration) for other settings that can be
     controlled by environment variables.*
 
 1. Deploy! :rocket:
@@ -148,15 +148,15 @@ create two settings before pushing using `heroku config:set`:
 
     heroku config:set DJANGO_SETTINGS_MODULE=babybuddy.settings.heroku
     heroku config:set SECRET_KEY=<CHANGE TO SOMETHING RANDOM>
-    
-See [Configuration](#configuration) for other settings that can be controlled 
+
+See [Configuration](#configuration) for other settings that can be controlled
 by `heroku config:set`.
-    
+
 ### Manual
 
 There are a number of ways to deploy Baby Buddy manually to any server/VPS.
-The application can run fine in low memory (below 1GB) situations, however a 
-32-bit operating system is recommended in such cases. This is primarily 
+The application can run fine in low memory (below 1GB) situations, however a
+32-bit operating system is recommended in such cases. This is primarily
 because the build process can be memory intensive and cause excessive memory
 usage on 64-bit systems. If all fails, assets can be built on a local machine
 and then uploaded to a server.
@@ -189,7 +189,7 @@ Python 3.x, nginx, uwsgi and sqlite and should be sufficient for a few users
         curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
         sudo apt-get install nodejs
         sudo npm install -g gulp-cli
-    
+
 1. Set up directories and files
 
         sudo mkdir /var/www/babybuddy
@@ -197,7 +197,7 @@ Python 3.x, nginx, uwsgi and sqlite and should be sufficient for a few users
         mkdir -p /var/www/babybuddy/data/media
         sudo chown -R www-data:www-data /var/www/babybuddy/data
         git clone https://github.com/cdubz/babybuddy.git /var/www/babybuddy/public
-    
+
 1. Move in to the application folder
 
         cd /var/www/babybuddy/public
@@ -205,12 +205,12 @@ Python 3.x, nginx, uwsgi and sqlite and should be sufficient for a few users
 1. Initiate the Python environment
 
         pipenv --three --dev
-    
+
 1. Build static assets
 
         npm install
         gulp build
-    
+
 1. Create a production settings file and set the ``SECRET_KEY`` and ``ALLOWED_HOSTS`` values
 
         cp babybuddy/settings/production.example.py babybuddy/settings/production.py
@@ -221,7 +221,7 @@ Python 3.x, nginx, uwsgi and sqlite and should be sufficient for a few users
         export DJANGO_SETTINGS_MODULE=babybuddy.settings.production
         gulp collectstatic
         gulp migrate
-    
+
 1. Set appropriate permissions on the database and data folder
 
         sudo chown www-data:www-data /var/www/babybuddy/data/db.sqlite3
@@ -233,27 +233,27 @@ Python 3.x, nginx, uwsgi and sqlite and should be sufficient for a few users
         sudo editor /etc/uwsgi/apps-available/babybuddy.ini
         sudo ln -s /etc/uwsgi/apps-available/babybuddy.ini /etc/uwsgi/apps-enabled/babybuddy.ini
         sudo service uwsgi restart
-    
+
     Example config:
-    
+
         [uwsgi]
         plugins = python3
         project = babybuddy
         base_dir = /var/www/babybuddy
-        
+
         virtualenv = /home/user/.local/share/virtualenvs/babybuddy-XXXXXXXX
         chdir = %(base_dir)/babybuddy
         module =  %(project).wsgi:application
         env = DJANGO_SETTINGS_MODULE=%(project).settings.production
         master = True
         vacuum = True
-    
-    See the [uWSGI documentation](http://uwsgi-docs.readthedocs.io/en/latest/) 
+
+    See the [uWSGI documentation](http://uwsgi-docs.readthedocs.io/en/latest/)
     for more advanced configuration details.
-    
-    *Note: Find the location of the pipenv virtual environment with the command 
+
+    *Note: Find the location of the pipenv virtual environment with the command
     ``pipenv --venv``.*
-    
+
 1. Create and configure the nginx server
 
         sudo vim /etc/nginx/sites-available/babybuddy
@@ -265,11 +265,11 @@ Python 3.x, nginx, uwsgi and sqlite and should be sufficient for a few users
         upstream babybuddy {
             server unix:///var/run/uwsgi/app/babybuddy/socket;
         }
-        
+
         server {
             listen 80;
             server_name babybuddy.example.com;
-        
+
             location / {
                 uwsgi_pass babybuddy;
                 include uwsgi_params;
@@ -278,7 +278,7 @@ Python 3.x, nginx, uwsgi and sqlite and should be sufficient for a few users
 
     See the [nginx documentation](https://nginx.org/en/docs/) for more advanced
     configuration details.
-    
+
 1. That's it (hopefully)! :tada:
 
 ## Configuration
@@ -295,12 +295,15 @@ take precedence over the contents of an `.env` file.**
 - [`NAP_START_MIN`](#nap_start_min)
 - [`SECRET_KEY`](#secret_key)
 - [`TIME_ZONE`](#time_zone)
+- [`AWS_STORAGE_BUCKET_NAME`](#aws_storage_bucket_name)
+- [`AWS_ACCESS_KEY_ID`](#aws_access_key_id)
+- [`AWS_SECRET_ACCESS_KEY`](#aws_secret_access_key)
 
 ### `ALLOWED_HOSTS`
 
 *Default: * (any)*
 
-This option may be set to a single host or comma-separated list of hosts 
+This option may be set to a single host or comma-separated list of hosts
 (without spaces). This should *always* be set to a specific host or hosts in
 production deployments.
 
@@ -310,7 +313,7 @@ See also: [Django's documentation on the ALLOWED_HOSTS setting](https://docs.dja
 
 *Default: True*
 
-Whether or not to allow uploads (e.g. of Child photos). For some deployments 
+Whether or not to allow uploads (e.g. of Child photos). For some deployments
 (AWS, Heroku, Nanobox) this setting will default to False due to the lack of
 available persistent storage.
 
@@ -341,7 +344,7 @@ entry is considered a nap. Expects the format %H:%M.
 
 *Default: None*
 
-A random, unique string must be set as the "secret key" before Baby Buddy can 
+A random, unique string must be set as the "secret key" before Baby Buddy can
 be deployed and run.
 
 See also [Django's documentation on the SECRET_KEY setting](https://docs.djangoproject.com/en/1.11/ref/settings/#secret-key).
@@ -353,16 +356,39 @@ See also [Django's documentation on the SECRET_KEY setting](https://docs.djangop
 The time zone to use for the instance. See [List of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
 for all possible values.
 
+### `AWS_STORAGE_BUCKET_NAME`
+
+*Default: None*
+
+If you would like to use AWS S3 for storage on ephemeral storage platforms like
+Heroku you will need to create a bucket and add it's name. See django-storages'
+[Amazon S3 documentation]
+(http://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html).
+
+### `AWS_ACCESS_KEY_ID`
+
+*Default: None*
+
+Required to access your AWS S3 bucket, should be uniquely generated per bucket
+for security.
+
+### `AWS_SECRET_ACCESS_KEY`
+
+*Default: None*
+
+Required to access your AWS S3 bucket, should be uniquely generated per bucket
+for security.
+
 ## API
 
 Baby Buddy uses the [Django REST Framework](http://www.django-rest-framework.org/)
 (DRF) to provide a REST API.
 
 The only requirement for (most) requests is that the `Authorization` header is
-set as described in the [Authentication](#authentication) section. The one 
+set as described in the [Authentication](#authentication) section. The one
 exception is the `/api` endpoint, which lists all available endpoints.
 
-Currently, the following endpoints are available for `GET`, `OPTIONS`, and 
+Currently, the following endpoints are available for `GET`, `OPTIONS`, and
 `POST` requests:
 
 - `/api/children/`
@@ -379,19 +405,19 @@ Currently, the following endpoints are available for `GET`, `OPTIONS`, and
 By default, the [TokenAuthentication](http://www.django-rest-framework.org/api-guide/authentication/#tokenauthentication)
 and [SessionAuthentication](http://www.django-rest-framework.org/api-guide/authentication/#sessionauthentication)
 classes are enabled. Session authentication covers local API requests made by
-the application itself. Token authentication allows external requests to be 
+the application itself. Token authentication allows external requests to be
 made.
 
-:exclamation: **In a production environment, token authentication should only 
+:exclamation: **In a production environment, token authentication should only
 be used for API calls to an `https` endpoint.** :exclamation:
 
-Each user is automatically assigned an API key that can be used for token 
+Each user is automatically assigned an API key that can be used for token
 authentication. This key can be found on the User Settings page for the logged
 in the user. To use a key for an API request, set the request `Authorization`
 header to `Token <user-key>`. E.g.
 
     Authorization: Token 2h23807gd72h7hop382p98hd823dw3g665g56
-    
+
 If the `Authorization` header is not set or the key is not valid, the API will
 return `403 Forbidden` with additional details in the response body.
 
@@ -410,8 +436,8 @@ will return five diaper changes starting from the 10th diaper change entry:
         "previous": "https://[...]/api/changes/?limit=5&offset=5",
         "results": [...]
     }
-    
-Field-based filters for specific endpoints can be found the in the `filters` 
+
+Field-based filters for specific endpoints can be found the in the `filters`
 field of the `OPTIONS` response for specific endpoints.
 
 #### Response
@@ -424,7 +450,7 @@ Returns JSON data in the response body in the following format:
         "previous":<url>,
         "results":[{...}]
     }
-    
+
 - `count`: Total number of records (*in the database*, not just the response).
 - `next`: URL for the next set of results.
 - `previous`: URL for the previous set of results.
@@ -440,7 +466,7 @@ about the endpoint's purpose, parameters, filters, etc.
 #### Response
 
 Returns JSON data in the response body describing the endpoint, available
-options for `POST` requests, and available filters for `GET` requests. The 
+options for `POST` requests, and available filters for `GET` requests. The
 following example describes the `/api/children` endpoint:
 
     {
@@ -476,19 +502,19 @@ following example describes the `/api/children` endpoint:
 
 #### Request
 
-To add new entries for a particular endpoint, send a `POST` request with the 
-entry data in JSON format in the request body. The `Content-Type` header for 
+To add new entries for a particular endpoint, send a `POST` request with the
+entry data in JSON format in the request body. The `Content-Type` header for
 `POST` request must be set to `application/json`.
 
-Regular sanity checks will be performed on relevant data. See the `OPTIONS` 
-response for a particular endpoint for details on required fields and data 
+Regular sanity checks will be performed on relevant data. See the `OPTIONS`
+response for a particular endpoint for details on required fields and data
 formats.
 
 #### Response
 
 Returns JSON data in the response body describing the added/updated instance or
 error details if errors exist. Errors are keyed by either the field in error or
-the general string "non_field_errors" (usually when validation incorporates 
+the general string "non_field_errors" (usually when validation incorporates
 multiple fields).
 
 ## Development
@@ -504,7 +530,7 @@ multiple fields).
 1. Install pipenv
 
         pip install pipenv
-        
+
 1. Install required Python packages, including dev packages
 
         pipenv install --dev
@@ -520,20 +546,20 @@ multiple fields).
 1. Set, at least, the `DJANGO_SETTINGS_MODULE` environment variable
 
         export DJANGO_SETTINGS_MODULE=babybuddy.settings.development
-    
-    This process will differ based on the host OS. The above example is for 
+
+    This process will differ based on the host OS. The above example is for
     Linux-based systems. See [Configuration](#configuration) for other settings
     and methods for defining them.
 
 1. Migrate the database
 
         gulp migrate
-        
+
 1. Build assets and run the server
 
         gulp
 
-    This command will also watch for file system changes to rebuild assets and 
+    This command will also watch for file system changes to rebuild assets and
     restart the server as needed.
 
 Open [http://127.0.0.1:8000](http://127.0.0.1:8000) and log in with the default
@@ -542,7 +568,7 @@ user name and password (`admin`/`admin`).
 ### Gulp commands
 
 Baby Buddy's Gulp commands are defined and configured by files in the
-[`gulpfile.js`](gulpfile.js) folder. Django's management commands are defined 
+[`gulpfile.js`](gulpfile.js) folder. Django's management commands are defined
 in the [`babybuddy/management/commands`](babybuddy/management/commands) folder.
 
 - [`gulp`](#gulp)
@@ -567,14 +593,14 @@ Executes the `build` and `watch` commands and runs Django's development server.
 
 #### `build`
 
-Creates all script, style and "extra" assets and places them in the 
+Creates all script, style and "extra" assets and places them in the
 `babybuddy/static` folder.
 
 #### `collectstatic`
 
 Executes Django's `collectstatic` management task. This task relies on files in
 the `babybuddy/static` folder, so generally `gulp build` should be run before
-this command for production deployments. Gulp also passes along 
+this command for production deployments. Gulp also passes along
 non-overlapping arguments for this command, e.g. `--no-input`.
 
 #### `compress`
@@ -591,14 +617,14 @@ settings information.
 
 #### `extras`
 
-Copies "extra" files (fonts, images and server root contents) to the build 
+Copies "extra" files (fonts, images and server root contents) to the build
 folder.
 
 #### `fake`
 
 Adds some fake data to the database. By default, ``fake`` creates one child and
-31 days of random data. Use the  `--children` and `--days` flags to change the 
-default values, e.g. `gulp fake --children 5 --days 7` to generate five fake 
+31 days of random data. Use the  `--children` and `--days` flags to change the
+default values, e.g. `gulp fake --children 5 --days 7` to generate five fake
 children and seven days of data for each.
 
 #### `lint`
@@ -607,39 +633,39 @@ Executes Python and SASS linting for all relevant source files.
 
 #### `makemigrations`
 
-Executes Django's `makemigrations` management task. Gulp also passes along 
+Executes Django's `makemigrations` management task. Gulp also passes along
 non-overlapping arguments for this command.
 
 #### `migrate`
 
-Executes Django's `migrate` management task. In addition to migrating the 
-database, this command creates the default `admin` user. Gulp also passes along 
+Executes Django's `migrate` management task. In addition to migrating the
+database, this command creates the default `admin` user. Gulp also passes along
 non-overlapping arguments for this command.
 
 #### `reset`
 
-Resets the database to a default state *with* one fake child and 31 days of 
+Resets the database to a default state *with* one fake child and 31 days of
 fake data.
 
 #### `runserver`
 
-Executes Django's `runserver` management task. Gulp also passes along 
+Executes Django's `runserver` management task. Gulp also passes along
 non-overlapping arguments for this command.
 
 #### `scripts`
 
-Builds and combines relevant application scripts. Generally this command does 
+Builds and combines relevant application scripts. Generally this command does
 not need to be executed independently - see the `build` command.
 
 #### `styles`
 
-Builds and combines SASS styles in to CSS files. Generally this command does 
+Builds and combines SASS styles in to CSS files. Generally this command does
 not need to be executed independently - see the `build` command.
 
 #### `test`
 
 Executes Baby Buddy's suite of tests.
 
-Gulp also passes along non-overlapping arguments for this command, however 
+Gulp also passes along non-overlapping arguments for this command, however
 individual tests cannot be run with this command. `python manage.py test` can be
 used for individual test execution.

--- a/babybuddy/settings/base.py
+++ b/babybuddy/settings/base.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     'rest_framework.authtoken',
     'widget_tweaks',
     'easy_thumbnails',
+    'storages',
 
     'django.contrib.admin',
     'django.contrib.auth',
@@ -132,13 +133,27 @@ STATICFILES_FINDERS = [
 
 STATIC_URL = '/static/'
 
-MEDIA_URL = '/media/'
-
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+
+WHITENOISE_ROOT = os.path.join(BASE_DIR, 'static', 'root')
+
+
+# Media files (User uploaded content)
+# https://docs.djangoproject.com/en/2.0/topics/files/
 
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 
-WHITENOISE_ROOT = os.path.join(BASE_DIR, 'static', 'root')
+MEDIA_URL = '/media/'
+
+AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME', None)
+
+AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID', None)
+
+AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY', None)
+
+if AWS_STORAGE_BUCKET_NAME:
+    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+    THUMBNAIL_DEFAULT_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 
 
 # Django Rest Framework

--- a/package-lock.json
+++ b/package-lock.json
@@ -7832,26 +7832,6 @@
         }
       }
     },
-    "tempusdominus-core": {
-      "version": "5.0.0-alpha12",
-      "resolved": "https://registry.npmjs.org/tempusdominus-core/-/tempusdominus-core-5.0.0-alpha12.tgz",
-      "integrity": "sha512-Zk6ecr+lr1kbAir8ilnoiZR1cgvLWr5AoUPW7FMY73u4DbvLTXA5T2Md9qH/9E8JNVV7QgFccrode5frlGYnyQ==",
-      "requires": {
-        "jquery": "3.3.1",
-        "moment": "2.20.1",
-        "moment-timezone": "0.4.1"
-      },
-      "dependencies": {
-        "moment-timezone": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.1.tgz",
-          "integrity": "sha1-gfWYw61eIs2teWtn7NjYjQ9bqgY=",
-          "requires": {
-            "moment": "2.20.1"
-          }
-        }
-      }
-    },
     "text-cache": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/text-cache/-/text-cache-4.1.0.tgz",


### PR DESCRIPTION
I believe this takes care of the rest of #13.

In the process it looks like my editor configuration automatically cleaned up all the excess spacing in the README. I can go back through and undo that if you like didn't notice till I did the pull request!