### PR TITLE
Modify app manifest to fix iOS link issue. Fixes #57.

### DIFF
--- a/babybuddy/static_src/root/site.webmanifest.json
+++ b/babybuddy/static_src/root/site.webmanifest.json
@@ -13,6 +13,9 @@
             "type": "image/png"
         }
     ],
+    "scope": "/",
+    "lang": "en-US",
+    "start_url": "/",
     "theme_color": "#ffffff",
     "background_color": "#ffffff",
     "display": "standalone"

--- a/babybuddy/templates/babybuddy/base.html
+++ b/babybuddy/templates/babybuddy/base.html
@@ -14,12 +14,15 @@
     <link rel="apple-touch-icon" sizes="180x180" href="{% static "babybuddy/root/apple-touch-icon.png" %}">
     <link rel="icon" type="image/png" sizes="32x32" href="{% static "babybuddy/root/favicon-32x32.png" %}">
     <link rel="icon" type="image/png" sizes="16x16" href="{% static "babybuddy/root/favicon-16x16.png" %}">
-    <link rel="manifest" href="{% static "babybuddy/root/site.webmanifest" %}">
+    <link rel="manifest" href="{% static "babybuddy/root/site.webmanifest.json" %}">
     <link rel="mask-icon" href="{% static "babybuddy/root/safari-pinned-tab.svg" %}" color="#226f97">
     <meta name="apple-mobile-web-app-title" content="Baby Buddy">
     <meta name="application-name" content="Baby Buddy">
     <meta name="msapplication-TileColor" content="#226f97">
     <meta name="theme-color" content="#ffffff">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="msapplication-starturl" content="/">
 </head>
 <body style="padding-top: 3rem;">
 


### PR DESCRIPTION
This will need to be tested on Android to ensure it doesn't break anything there, but I don't envision that it does. Moreover, the simpler fix could be to ensure the web server provides `site.webmanifest` as a `Content-Type: application/json` MIME type.