### PR TITLE
Use pre-built docker image for compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,16 +8,14 @@ services:
     volumes:
        - db:/db-data
   app:
-    env_file: docker.env
-    build: .
+    image: cosme/babybuddy
+    env_file: 
+      - /path/to/docker.env
     command: gunicorn -c /app/gunicorn.py babybuddy.wsgi
     ports:
       - "8000:8000"
     depends_on:
       - db
-    volumes:
-      - baby_data:/app
 
 volumes:
    db:
-   baby_data:


### PR DESCRIPTION
The current setup for docker compose installation requires a local build of the docker image.
IMHO it defeats the whole purpose of Docker which should be plug-and-play.

Providing a pre-built docker image is as easy as creating a free account on docker hub and linking it to the master branch of the github repo.

I did it on my forked repo but it would be better to have it available directly on your repo. In that cas the image name should of course be updated to match yours.

Also I am sure that the final built image could be lighter but I don't know the app enough to identify the minimum requirements for production.