### PR TITLE
Add dashboard sort clauses: first name and id

### DIFF
--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -29,7 +29,8 @@ class Dashboard(LoginRequiredMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super(Dashboard, self).get_context_data(**kwargs)
-        context['objects'] = Child.objects.all().order_by('last_name')
+        context['objects'] = Child.objects.all() \
+            .order_by('last_name', 'first_name', 'id')
         return context
 
 


### PR DESCRIPTION
I have seen the dashboard sorting be inconsistent. Last name then
first name then id should produce a consistent and predictable
sort order.